### PR TITLE
2 crash when copying symbolic links with missing targets

### DIFF
--- a/src/actions/preserve.rs
+++ b/src/actions/preserve.rs
@@ -1,6 +1,7 @@
 use super::{ActRet, PostAction, PreAction};
 use anyhow::Context;
 use filetime;
+use log::debug;
 use std::fs;
 use std::os::unix::fs::MetadataExt;
 
@@ -46,20 +47,35 @@ impl PostAction for PreserveAction {
         for attr in self.attrs.iter() {
             match attr.as_str() {
                 "mode" => {
-                    fs::set_permissions(des, src_metadata.permissions())
-                        .with_context(|| format!("Failed to set permissions for: {}", des))?;
+                    match fs::set_permissions(des, src_metadata.permissions()) {
+                        Ok(_) => {}
+                        Err(e) => {
+                            debug!("Failed to set permissions for: {}", des);
+                            debug!("Error: {}", e);
+                        }
+                    };
                 }
                 "ownership" => {
                     let uid = nix::unistd::Uid::from_raw(src_metadata.uid());
                     let gid = nix::unistd::Gid::from_raw(src_metadata.gid());
-                    nix::unistd::chown(des, Some(uid), Some(gid))
-                        .with_context(|| format!("Failed to set ownership for: {}", des))?;
+                    match nix::unistd::chown(des, Some(uid), Some(gid)) {
+                        Ok(_) => {}
+                        Err(e) => {
+                            debug!("Failed to set ownership for: {}", des);
+                            debug!("Error: {}", e);
+                        }
+                    };
                 }
                 "timestamps" => {
                     let atime = filetime::FileTime::from_last_access_time(&src_metadata);
                     let mtime = filetime::FileTime::from_last_modification_time(&src_metadata);
-                    filetime::set_file_times(des, atime, mtime)
-                        .with_context(|| format!("Failed to set timestamps for: {}", des))?;
+                    match filetime::set_file_times(des, atime, mtime) {
+                        Ok(_) => {}
+                        Err(e) => {
+                            debug!("Failed to set timestamps for: {}", des);
+                            debug!("Error: {}", e);
+                        }
+                    };
                 }
                 _ => {}
             }

--- a/src/actions/recursive.rs
+++ b/src/actions/recursive.rs
@@ -1,14 +1,14 @@
 use super::{ActRet, PreAction};
-use anyhow::Context;
-
+use std::path::Path;
 pub struct RecursiveAction;
 
 impl PreAction for RecursiveAction {
     fn pre_run(&self, src: &str, des: &str) -> anyhow::Result<ActRet> {
-        if std::fs::metadata(src)
-            .with_context(|| format!("Failed to get metadata of {}", src))?
-            .is_dir()
-        {
+        let src_path = Path::new(src);
+
+        if !src_path.exists() {
+            Err(anyhow::anyhow!("Source path does not exist: {}", src))
+        } else if src_path.is_dir() && !src_path.is_symlink() {
             // create directory
             match std::fs::create_dir(des) {
                 Ok(_) => Ok(ActRet::SkipCopy),

--- a/tests/system_tests.rs
+++ b/tests/system_tests.rs
@@ -268,7 +268,7 @@ fn test_archive_option_with_symlink() {
     let src_dir = temp_dir.path().join("src_dir");
     fs::create_dir_all(&src_dir).unwrap();
 
-    // Create files in sub-directories
+    // Create files
     let src_file = src_dir.join("src.txt");
     let link_file = src_dir.join("link.txt");
 
@@ -287,7 +287,6 @@ fn test_archive_option_with_symlink() {
         .arg(&src_file)
         .arg("--")
         .arg(&des_dir);
-    println!("Command: {:?}", cmd);
     cmd.assert().success();
 
     // Verify files are copied

--- a/tests/system_tests.rs
+++ b/tests/system_tests.rs
@@ -300,3 +300,46 @@ fn test_archive_option_with_symlink() {
         fs::read_link(&link_file).unwrap()
     );
 }
+
+#[test]
+fn test_archive_option_with_symlink_dir() {
+    let temp_dir = tempfile::tempdir_in(".").unwrap();
+
+    // Create a directory structure
+    let src_dir = temp_dir.path().join("src_dir");
+    fs::create_dir_all(&src_dir).unwrap();
+
+    // Create files
+    let src_file = src_dir.join("src.txt");
+    fs::write(&src_file, "Main content").unwrap();
+
+    // Create a symlink to the directory, using the relative path
+    let link_dir = temp_dir.path().join("link_dir");
+    std::os::unix::fs::symlink(&src_dir.file_name().unwrap(), &link_dir).unwrap();
+
+    // Create destination directory
+    let des_dir = temp_dir.path().join("des_dir");
+    fs::create_dir_all(&des_dir).unwrap();
+
+    // Run the command with --archive option
+    let mut cmd = Command::cargo_bin("pbcp").unwrap();
+    cmd.arg("-a")
+        .arg(&link_dir)
+        .arg(&src_dir)
+        .arg("--")
+        .arg(&des_dir);
+    cmd.assert().success();
+
+    // Verify files are copied to the destination directory
+    let des_src_file = des_dir.join("src_dir").join("src.txt");
+    let des_link_dir = des_dir.join("link_dir");
+    let des_link_file = des_dir.join("link_dir").join("src.txt");
+
+    assert!(des_src_file.exists());
+    assert!(des_link_dir.is_symlink());
+    assert_eq!(
+        fs::read_link(&des_link_dir).unwrap(),
+        fs::read_link(&link_dir).unwrap()
+    );
+    assert_eq!(fs::read_to_string(&des_link_file).unwrap(), "Main content");
+}

--- a/utils/scanner/src/scanners/basescanner.rs
+++ b/utils/scanner/src/scanners/basescanner.rs
@@ -32,7 +32,11 @@ impl DirScan for BaseScanner<'_> {
             .with_context(|| format!("failed to read metadata of {}", cur_entry))?;
 
         if metadata.is_dir() {
-            for entry in WalkDir::new(cur_entry).into_iter().filter_map(Result::ok) {
+            for entry in WalkDir::new(cur_entry)
+                .follow_root_links(false)
+                .into_iter()
+                .filter_map(Result::ok)
+            {
                 let src_entry = entry.path().to_str().unwrap();
                 trace!("{} found!", src_entry);
 


### PR DESCRIPTION
Fix two bugs related to symbolic link copying:
- Copying symbolic links before their target files causes program failure.
- The program incorrectly handles directory symbolic links, treating them as regular directories and leading to the simultaneous creation of both actual directories and symbolic links.